### PR TITLE
Switched to main repo for agrifoodpy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,4 @@ dependencies:
   - pip:
     - millify
     - fair==1.6.4
-    - -e git+https://github.com/FixOurFood/AgriFoodPy-light.git#egg=agrifoodpy
+    - -e git+https://github.com/FixOurFood/AgriFoodPy.git@streamlit_dashboard#egg=agrifoodpy


### PR DESCRIPTION
Last version of the main dashboard used a light version of agrifoodpy. Tested with the full main repo and seems to work just fine, so I'm switching the requirements file to clone directly from that repository