### PR TITLE
Fair2

### DIFF
--- a/afp_config.py
+++ b/afp_config.py
@@ -131,8 +131,10 @@ group_names = np.unique(food_uk.Item_group.values)
 # Atmosferic model - Baseline run
 # -------------------------------
 
+# Convert from grams to Gt /1e15
+# Convert from GtCO2 to GtC /3.664
 
-total_emissions_gtco2e_baseline = (co2e_year_baseline["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15
+total_emissions_gtco2e_baseline = (co2e_year_baseline["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15/3.664
 C_base, F_base, T_base = fair.forward.fair_scm(total_emissions_gtco2e_baseline, useMultigas=False)
 
 # --------------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,5 @@ dependencies:
   - pip
   - pip:
     - millify
-    - fair==1.6.4
+    - fair
     - -e git+https://github.com/FixOurFood/AgriFoodPy.git@streamlit_dashboard#egg=agrifoodpy

--- a/fair_config.py
+++ b/fair_config.py
@@ -1,0 +1,50 @@
+from fair import FAIR
+import xarray as xr
+from fair.interface import fill, initialise
+
+def set_fair_base():
+    fair_base = FAIR()
+
+    fair_base.ghg_method='myhre1998'
+
+    # Define timebounds
+    fair_base.define_time(1960.5, 2100.5, 1)
+
+    # Define scenarios
+    fair_base.define_scenarios(["afp"])
+
+    # Define configurations
+    fair_base.define_configs(["defaults"])
+
+    # Define species and their properties
+    species = ['CO2']
+    properties = {
+        'CO2': {
+            'type': 'co2',
+            'input_mode': 'emissions',
+            'greenhouse_gas': True,  # it doesn't behave as a GHG itself in the model, but as a precursor
+            'aerosol_chemistry_from_emissions': False,
+            'aerosol_chemistry_from_concentration': False,
+        }}
+
+    fair_base.define_species(species, properties)
+
+    # Allocate arrays
+    fair_base.allocate()
+
+    # Set climate configs
+    fill(fair_base.climate_configs["ocean_heat_transfer"], [1.1, 1.6, 0.9], config='defaults')
+    fill(fair_base.climate_configs["ocean_heat_capacity"], [8, 14, 100], config='defaults')
+    fill(fair_base.climate_configs["deep_ocean_efficacy"], 1.1, config='defaults')
+
+    # Set initial conditions
+    initialise(fair_base.concentration, 278.3, specie='CO2')
+    initialise(fair_base.forcing, 0)
+    initialise(fair_base.temperature, 0)
+    initialise(fair_base.cumulative_emissions, 0)
+    initialise(fair_base.airborne_emissions, 0)
+
+    # Fill species configs
+    fair_base.fill_species_configs()
+
+    return fair_base

--- a/streamlite_app.py
+++ b/streamlite_app.py
@@ -288,7 +288,7 @@ with col2:
     c = None
     f, plot1 = plt.subplots(1, figsize=(4,4))
 
-    total_emissions_gtco2e = (co2e_year["food"]*scaling["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15
+    total_emissions_gtco2e = (co2e_year["food"]*scaling["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15/3.664
     # C, F, T = fair.forward.fair_scm(, useMultigas=False)
     C, F, T = FAIR_run(total_emissions_gtco2e)
 

--- a/streamlite_app.py
+++ b/streamlite_app.py
@@ -14,6 +14,7 @@ import custom_widgets as cw
 from glossary import *
 from afp_config import *
 from altair_plots import *
+from fair_config import set_fair_base
 
 from helper_functions import *
 from model import *
@@ -288,9 +289,15 @@ with col2:
     c = None
     f, plot1 = plt.subplots(1, figsize=(4,4))
 
-    total_emissions_gtco2e = (co2e_year["food"]*scaling["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15/3.664
-    # C, F, T = fair.forward.fair_scm(, useMultigas=False)
-    C, F, T = FAIR_run(total_emissions_gtco2e)
+    total_emissions_gtco2e = (co2e_year["food"]*scaling["food"] * pop_world / pop_uk).sum(dim="Item").to_numpy()/1e15
+    
+    fair_run = set_fair_base()
+    fair_run.emissions.loc[{"scenario":"afp", "specie":"CO2", "config":"defaults"}] = total_emissions_gtco2e
+    fair_run.run(progress=False)
+    
+    T = fair_run.temperature.loc[dict(scenario='afp', layer=0)].values.squeeze()
+    F = fair_run.forcing.loc[dict(scenario='afp', specie="CO2")].values.squeeze()
+    C = fair_run.concentration.loc[dict(scenario='afp', specie="CO2")].values.squeeze()
 
     if plot_key == "CO2e emission per food group":
 
@@ -325,20 +332,33 @@ with col2:
 
     elif plot_key == "Temperature anomaly":
 
-        T_base_xr = xr.DataArray(data=T_base,
+        T_base_xr = xr.DataArray(data=T_base-T_base[-80],
                                  dims=["Year"],
-                                 coords={"Year":years})
+                                 coords={"Year":fair_run.timebounds.astype(int)})
 
-        T_xr = xr.DataArray(data=T,
+        T_xr = xr.DataArray(data=T-T[-80],
                                  dims=["Year"],
-                                 coords={"Year":years})
+                                 coords={"Year":fair_run.timebounds.astype(int)})
+        
         
         c = plot_years_total(T_xr, xlabel="Atmosferic temperature warming [ºC]").mark_line(color='black')
         c = c + plot_years_total(T_base_xr, xlabel="Atmosferic temperature warming [ºC]")
+
         c = c.configure_axis(
             labelFontSize=15,
             titleFontSize=15
             )
+        
+        rules = alt.Chart(pd.DataFrame({
+            'Year': [2020],
+            'color': ['grey']
+            })).mark_rule().encode(
+            x='Year:T',
+            color=alt.Color('color:N', scale=None)
+        )
+        
+        c = c+rules
+
 
     elif plot_key == "Per capita daily values":
         option_key = st.selectbox("Plot options", list(baseline.keys()))
@@ -360,8 +380,8 @@ with col2:
             )
         
         c = c.configure_axis(
-            labelFontSize=15,
-            titleFontSize=15
+            labelFontSize=20,
+            titleFontSize=20
         )
 
     elif plot_key == "Self-sufficiency ratio":
@@ -372,8 +392,6 @@ with col2:
             labelFontSize=15,
             titleFontSize=15
             )
-
-        print(SSR_scaled)
 
     elif plot_key == "Land Use":
         col_opt1, col_opt2 = st.columns((1,1))


### PR DESCRIPTION
Switched to the latest version of FaIR.
Added a default configuration object which can be imported to run separate runs of the same configuration.

FaIR 2 takes an array of Gt CO2/yr emissions rather than Gt C/yr.
This now yields a "correct" value for the warming by 2100.

The plan is to move to a different approach for food related warming, using emissions from a reference scenario and then comparing against a run with subtracted agrifood emissions

This closes #15 