### PR TITLE
Added check for non existing dims in altair plots

### DIFF
--- a/altair_plots.py
+++ b/altair_plots.py
@@ -29,7 +29,7 @@ def plot_years_altair(food, show="Item", xlabel=None, **kwargs):
 
 def plot_years_total(food, xlabel=None, sumdim=None):
     years = food.Year.values
-    if sumdim is not None:
+    if sumdim is not None and sumdim in food.dims:
         total = food.sum(dim="Item")
     else:
         total = food


### PR DESCRIPTION
This PR fixes an issue when plotting time series for arrays with a single elemenent along the "Item" dimension, mentioned in #24 

Added an additional condition to check if a dimension to sum over is present in the array. If not, the full array is used for the plot rather than a dissagregated version